### PR TITLE
Changed the storage VHD Full Path to AbsoluteUri

### DIFF
--- a/Az-Module/Az-Module.psm1
+++ b/Az-Module/Az-Module.psm1
@@ -292,7 +292,7 @@ Function Get-AzOrphanedVhd {
 				SizeGB         = [Math]::Round($Vhd.Length/1GB,0)
 				Modified       = $ModifiedLocal.ToString('dd/MM/yyyy HH:mm')
 				LastWriteDays  = $Days
-				FullPath       = ($Vhd.ICloudBlob.Uri) -replace ($rgxUrl,'')
+				FullPath       = ($Vhd.ICloudBlob.Uri.AbsoluteUri) -replace ($rgxUrl,'')
 				Snapshot       = $Vhd.ICloudBlob.IsSnapshot
 			}
 			$Object = New-Object PSObject -Property $Properties


### PR DESCRIPTION
Disks created from Azure Site Recovery service are named "copied-{XXXXXXX}.vhd". Most powershell queries will show the URI using the ASCII codes not the characters, for example "copied-%7BXXXXXXX%7D". The parameter .ICloudBlob.Uri shows the display name of the vhd using the characters {} thus not matching in the final check against the lists. Using .ICloudBlob.Uri.AbsoluteURI returns the ascii code URI matching the previous VM Vhd list.

This only affects the matching, thankfully all other information was pulled and I was able to spot the active / attached disks based on their modified date.